### PR TITLE
Changed Defaults for EW6&EW7, added CSAR Callsigns

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -466,12 +466,12 @@ theaters:
         laser: 175
       edelweiss_6:
         freq: 134.65
-        laser: 176
-        group: 46
+        laser: 166
+        group: 40
       edelweiss_7:
         freq: 134.75
-        laser: 177
-        group: 47
+        laser: 167
+        group: 41
     channels:
       - name: Flight/Squadron specific
       - name: Nellis Clearance Delivery
@@ -5128,6 +5128,8 @@ callsigns:
   - Warrior
   - Wizzard
   - Zapper
+  - Dustoff
+  - Medevac
 missions:
   - Training
   - AWACS

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5129,7 +5129,6 @@ callsigns:
   - Wizzard
   - Zapper
   - Dustoff
-  - Medevac
 missions:
   - Training
   - AWACS


### PR DESCRIPTION
-Changed default lasercodes and SADL for Edelweiss 6 and Edelweiss 7 to a value that can be set in FPT and ingame. Former values where out of bounds.
-Added Dustoff and Medevac to the callsign pool.