### PR TITLE
NTTR AAR Tacan FIX?

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -777,7 +777,7 @@ theaters:
         type: TANKER
         airframe: KC-130
         comms: 300.05
-        tacan: 31Y
+        tacan: 22Y
         position: "AR-231V: BTY 126/37 (N3620 W11614)"
         altitude: 8000
         speed: 320


### PR DESCRIPTION
Habe die AAR einheiten neu Platziert und bei Track AR-231V hatten wir eine überschneidung mit 641A (AR-231V = 31Y + AR-641A = 94Y)
Offline getestet alle sind bei mir mit Y gespawnt.